### PR TITLE
chore: Bump to a required babylon version instead of release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/babylonchain/rpc-client
 go 1.18
 
 require (
-	github.com/babylonchain/babylon v0.3.0
+	github.com/babylonchain/babylon v0.0.0-20221208092040-2ca49f0e68cb
 	github.com/btcsuite/btcd v0.22.1
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1
 	github.com/cosmos/cosmos-sdk v0.46.6
@@ -89,6 +89,7 @@ require (
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hdevalence/ed25519consensus v0.0.0-20220222234857-c00d1f31bab3 // indirect
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
+	github.com/jinzhu/copier v0.3.5 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/jmhodges/levigo v1.0.0 // indirect
 	github.com/keybase/go-keychain v0.0.0-20190712205309-48d3d31d256d // indirect

--- a/go.sum
+++ b/go.sum
@@ -95,8 +95,10 @@ github.com/avast/retry-go/v4 v4.3.0/go.mod h1:bqOlT4nxk4phk9buiQFaghzjpqdchOSwPg
 github.com/aws/aws-sdk-go v1.15.78/go.mod h1:E3/ieXAlvM0XWO57iftYVDLLvQ824smPP3ATZkfNZeM=
 github.com/aws/aws-sdk-go v1.40.45 h1:QN1nsY27ssD/JmW4s83qmSb+uL6DG4GmCDzjmJB4xUI=
 github.com/aws/aws-sdk-go v1.40.45/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
-github.com/babylonchain/babylon v0.3.0 h1:DddCv+LwQSueI0E0htBM7/Pg8FtOkwCqCbObdFpvFaI=
-github.com/babylonchain/babylon v0.3.0/go.mod h1:+9sTq4zACOGbeyqaKGjOW4+Z1XbQbh4DRwRX77Uq4Vg=
+github.com/babylonchain/babylon v0.0.0-20221208042204-fb7a231ca5fc h1:ufDCXJNxhwD6XbVN3S+0A0bgAgTQlh6xXxIntxWBYX4=
+github.com/babylonchain/babylon v0.0.0-20221208042204-fb7a231ca5fc/go.mod h1:EDMWjAsA2+fRWMXlR1dNhxCuiWfk8BWob35L2oo2v94=
+github.com/babylonchain/babylon v0.0.0-20221208092040-2ca49f0e68cb h1:w2EFInWsFJrXDlTXm7U3yuR+f5JDLgtHNwnZLMDMyB4=
+github.com/babylonchain/babylon v0.0.0-20221208092040-2ca49f0e68cb/go.mod h1:EDMWjAsA2+fRWMXlR1dNhxCuiWfk8BWob35L2oo2v94=
 github.com/babylonchain/ibc-go/v5 v5.0.1-0.20221107054049-dbf7e4efe6fd h1:0y7HPL7xb/N1Oa/q5cQJ80K3ZfnQoKSG5sveZwpm0/E=
 github.com/babylonchain/ibc-go/v5 v5.0.1-0.20221107054049-dbf7e4efe6fd/go.mod h1:Wqsguq98Iuns8tgTv8+xaGYbC+Q8zJfbpjzT6IgMJbs=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
@@ -412,6 +414,8 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
+github.com/jinzhu/copier v0.3.5 h1:GlvfUwHk62RokgqVNvYsku0TATCF7bAHVwEXoBh3iJg=
+github.com/jinzhu/copier v0.3.5/go.mod h1:DfbEm0FYsaqBcKcFuvmOZb218JkPGtvSHsKg8S8hyyg=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=

--- a/testutil/mocks/client.go
+++ b/testutil/mocks/client.go
@@ -42,6 +42,21 @@ func (m *MockBabylonClient) EXPECT() *MockBabylonClientMockRecorder {
 	return m.recorder
 }
 
+// BlsPublicKeyList mocks base method.
+func (m *MockBabylonClient) BlsPublicKeyList(epochNumber uint64) ([]*types1.ValidatorWithBlsKey, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BlsPublicKeyList", epochNumber)
+	ret0, _ := ret[0].([]*types1.ValidatorWithBlsKey)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// BlsPublicKeyList indicates an expected call of BlsPublicKeyList.
+func (mr *MockBabylonClientMockRecorder) BlsPublicKeyList(epochNumber interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlsPublicKeyList", reflect.TypeOf((*MockBabylonClient)(nil).BlsPublicKeyList), epochNumber)
+}
+
 // GetAddr mocks base method.
 func (m *MockBabylonClient) GetAddr() (types3.AccAddress, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
In order to not block the dev process, maybe it is good to make `dev` branch depend on the required Babylon version. But one note is that when making the next release, the dependency should be a released Babylon version.