### PR TITLE
feat: Add current epoch query

### DIFF
--- a/client/interface.go
+++ b/client/interface.go
@@ -28,6 +28,7 @@ type BabylonClient interface {
 
 	// epoch module related queries
 	QueryEpochingParams() (*epochingtypes.Params, error)
+	QueryCurrentEpoch() (uint64, error)
 
 	// btclightclient module related queries
 	QueryBTCLightclientParams() (*btclctypes.Params, error)

--- a/client/query_epoching.go
+++ b/client/query_epoching.go
@@ -20,3 +20,24 @@ func (c *Client) QueryEpochingParams() (*epochingtypes.Params, error) {
 	}
 	return &resp.Params, nil
 }
+
+// QueryCurrentEpoch queries the current epoch number via ChainClient
+func (c *Client) QueryCurrentEpoch() (uint64, error) {
+	var (
+		epochNum uint64
+		err      error
+	)
+
+	q := query.Query{Client: c.ChainClient, Options: query.DefaultOptions()}
+	ctx, cancel := q.GetQueryContext()
+	defer cancel()
+
+	queryClient := epochingtypes.NewQueryClient(c.ChainClient)
+	req := &epochingtypes.QueryCurrentEpochRequest{}
+	resp, err := queryClient.CurrentEpoch(ctx, req)
+	if err != nil {
+		return epochNum, err
+	}
+
+	return resp.CurrentEpoch, nil
+}


### PR DESCRIPTION
This PR adds a query for the current epoch number provided by the epoching module, which is required by the [verifier](https://github.com/babylonchain/ledger-verifier).