### PR TITLE
fix: introduce config file for `QueryClient`

### DIFF
--- a/config/babylon_config.go
+++ b/config/babylon_config.go
@@ -1,7 +1,8 @@
 package config
 
 import (
-	"errors"
+	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"time"
@@ -47,11 +48,14 @@ type BabylonConfig struct {
 }
 
 func (cfg *BabylonConfig) Validate() error {
+	if _, err := url.Parse(cfg.RPCAddr); err != nil {
+		return fmt.Errorf("cfg.RPCAddr is not correctly formatted: %w", err)
+	}
 	if cfg.Timeout <= 0 {
-		return errors.New("cfg.Timeout must be positive")
+		return fmt.Errorf("cfg.Timeout must be positive")
 	}
 	if cfg.BlockTimeout < 0 {
-		return errors.New("cfg.BlockTimeout can't be negative")
+		return fmt.Errorf("cfg.BlockTimeout can't be negative")
 	}
 	return nil
 }

--- a/config/babylon_query_config.go
+++ b/config/babylon_query_config.go
@@ -1,0 +1,26 @@
+package config
+
+import (
+	"errors"
+	"time"
+)
+
+// BabylonConfig defines configuration for the Babylon query client
+type BabylonQueryConfig struct {
+	RPCAddr string        `mapstructure:"rpc-addr"`
+	Timeout time.Duration `mapstructure:"timeout"`
+}
+
+func (cfg *BabylonQueryConfig) Validate() error {
+	if cfg.Timeout <= 0 {
+		return errors.New("cfg.Timeout must be positive")
+	}
+	return nil
+}
+
+func DefaultBabylonQueryConfig() BabylonQueryConfig {
+	return BabylonQueryConfig{
+		RPCAddr: "http://localhost:26657",
+		Timeout: 20 * time.Second,
+	}
+}

--- a/config/babylon_query_config.go
+++ b/config/babylon_query_config.go
@@ -1,7 +1,8 @@
 package config
 
 import (
-	"errors"
+	"fmt"
+	"net/url"
 	"time"
 )
 
@@ -12,8 +13,11 @@ type BabylonQueryConfig struct {
 }
 
 func (cfg *BabylonQueryConfig) Validate() error {
+	if _, err := url.Parse(cfg.RPCAddr); err != nil {
+		return fmt.Errorf("cfg.RPCAddr is not correctly formatted: %w", err)
+	}
 	if cfg.Timeout <= 0 {
-		return errors.New("cfg.Timeout must be positive")
+		return fmt.Errorf("cfg.Timeout must be positive")
 	}
 	return nil
 }

--- a/config/babylon_query_config_test.go
+++ b/config/babylon_query_config_test.go
@@ -1,0 +1,15 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/babylonchain/rpc-client/config"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBabylonQueryConfig ensures that the default Babylon query config is valid
+func TestBabylonQueryConfig(t *testing.T) {
+	defaultConfig := config.DefaultBabylonQueryConfig()
+	err := defaultConfig.Validate()
+	require.NoError(t, err)
+}

--- a/query/client.go
+++ b/query/client.go
@@ -24,7 +24,7 @@ type QueryClient struct {
 	timeout   time.Duration
 }
 
-// NewWithClient creates a new QueryClient to a given rpcAddr and a given timeout
+// NewWithClient creates a new QueryClient according to the given config
 func New(cfg *config.BabylonQueryConfig) (*QueryClient, error) {
 	if err := cfg.Validate(); err != nil {
 		return nil, err

--- a/query/client.go
+++ b/query/client.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/babylonchain/rpc-client/config"
 	"github.com/cosmos/cosmos-sdk/client"
 	grpctypes "github.com/cosmos/cosmos-sdk/types/grpc"
 	lensquery "github.com/strangelove-ventures/lens/client/query"
@@ -24,25 +25,26 @@ type QueryClient struct {
 }
 
 // NewWithClient creates a new QueryClient to a given rpcAddr and a given timeout
-func New(rpcAddr string, timeout time.Duration) (*QueryClient, error) {
-	if timeout <= 0 {
-		return nil, fmt.Errorf("timeout must be positive")
+func New(cfg *config.BabylonQueryConfig) (*QueryClient, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
 	}
 
-	tmClient, err := client.NewClientFromNode(rpcAddr)
+	tmClient, err := client.NewClientFromNode(cfg.RPCAddr)
 	if err != nil {
 		return nil, err
 	}
 
 	client := &QueryClient{
 		RPCClient: tmClient,
-		timeout:   timeout,
+		timeout:   cfg.Timeout,
 	}
 
 	return client, nil
 }
 
 // NewWithClient creates a new QueryClient with a given existing rpcClient and timeout
+// used by `client/` where `ChainClient` already creates an rpc client
 func NewWithClient(rpcClient rpcclient.Client, timeout time.Duration) (*QueryClient, error) {
 	if timeout <= 0 {
 		return nil, fmt.Errorf("timeout must be positive")

--- a/query/staking_test.go
+++ b/query/staking_test.go
@@ -29,8 +29,8 @@ func TestStakingParams(t *testing.T) {
 	err = testNetwork.WaitForNextBlock()
 	require.NoError(t, err)
 
-	clientCfg := config.DefaultBabylonConfig()
-	client, err := query.New(clientCfg.RPCAddr, clientCfg.Timeout)
+	queryCfg := config.DefaultBabylonQueryConfig()
+	client, err := query.New(&queryCfg)
 	require.NoError(t, err)
 	params, err := client.StakingParams()
 	require.NoError(t, err)


### PR DESCRIPTION
This PR introduces `BabylonQueryConfig`, the config struct dedicated for `QueryClient`. This formalises and simplifies development of other projects that use `QueryClient`.