### PR TITLE
fix: add monitor module to ModuleBasics and refactor codec

### DIFF
--- a/config/babylon_config.go
+++ b/config/babylon_config.go
@@ -11,6 +11,7 @@ import (
 	"github.com/babylonchain/babylon/x/btclightclient"
 	"github.com/babylonchain/babylon/x/checkpointing"
 	"github.com/babylonchain/babylon/x/epoching"
+	"github.com/babylonchain/babylon/x/monitor"
 	"github.com/babylonchain/babylon/x/zoneconcierge"
 	"github.com/strangelove-ventures/lens/client"
 )
@@ -24,6 +25,7 @@ var ModuleBasics = append(
 	btclightclient.AppModuleBasic{},
 	btccheckpoint.AppModuleBasic{},
 	zoneconcierge.AppModuleBasic{},
+	monitor.AppModuleBasic{},
 )
 
 // BabylonConfig defines configuration for the Babylon client

--- a/config/babylon_config.go
+++ b/config/babylon_config.go
@@ -7,25 +7,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/babylonchain/babylon/x/btccheckpoint"
-	"github.com/babylonchain/babylon/x/btclightclient"
-	"github.com/babylonchain/babylon/x/checkpointing"
-	"github.com/babylonchain/babylon/x/epoching"
-	"github.com/babylonchain/babylon/x/monitor"
-	"github.com/babylonchain/babylon/x/zoneconcierge"
 	"github.com/strangelove-ventures/lens/client"
-)
-
-// ModuleBasics is the list of modules used in Babylon
-// necessary for serialising/deserialising Babylon messages/queries
-var ModuleBasics = append(
-	client.ModuleBasics,
-	epoching.AppModuleBasic{},
-	checkpointing.AppModuleBasic{},
-	btclightclient.AppModuleBasic{},
-	btccheckpoint.AppModuleBasic{},
-	zoneconcierge.AppModuleBasic{},
-	monitor.AppModuleBasic{},
 )
 
 // BabylonConfig defines configuration for the Babylon client

--- a/config/codec.go
+++ b/config/codec.go
@@ -1,0 +1,29 @@
+package config
+
+import (
+	"github.com/babylonchain/babylon/x/btccheckpoint"
+	"github.com/babylonchain/babylon/x/btclightclient"
+	"github.com/babylonchain/babylon/x/checkpointing"
+	"github.com/babylonchain/babylon/x/epoching"
+	"github.com/babylonchain/babylon/x/monitor"
+	"github.com/babylonchain/babylon/x/zoneconcierge"
+	"github.com/strangelove-ventures/lens/client"
+	lensclient "github.com/strangelove-ventures/lens/client"
+)
+
+// ModuleBasics is the list of modules used in Babylon
+// necessary for serialising/deserialising Babylon messages/queries
+var ModuleBasics = append(
+	client.ModuleBasics,
+	epoching.AppModuleBasic{},
+	checkpointing.AppModuleBasic{},
+	btclightclient.AppModuleBasic{},
+	btccheckpoint.AppModuleBasic{},
+	zoneconcierge.AppModuleBasic{},
+	monitor.AppModuleBasic{},
+)
+
+// GetBabylonCdc returns Codec, i.e., struct for encoding/decoding messages, for Babylon
+func GetCodec() lensclient.Codec {
+	return lensclient.MakeCodec(ModuleBasics)
+}

--- a/config/codec.go
+++ b/config/codec.go
@@ -8,14 +8,13 @@ import (
 	"github.com/babylonchain/babylon/x/epoching"
 	"github.com/babylonchain/babylon/x/monitor"
 	"github.com/babylonchain/babylon/x/zoneconcierge"
-	"github.com/strangelove-ventures/lens/client"
 	lensclient "github.com/strangelove-ventures/lens/client"
 )
 
 // ModuleBasics is the list of modules used in Babylon
 // necessary for serialising/deserialising Babylon messages/queries
 var ModuleBasics = append(
-	client.ModuleBasics,
+	lensclient.ModuleBasics,
 	epoching.AppModuleBasic{},
 	checkpointing.AppModuleBasic{},
 	btclightclient.AppModuleBasic{},

--- a/config/codec.go
+++ b/config/codec.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	appparams "github.com/babylonchain/babylon/app/params"
 	"github.com/babylonchain/babylon/x/btccheckpoint"
 	"github.com/babylonchain/babylon/x/btclightclient"
 	"github.com/babylonchain/babylon/x/checkpointing"
@@ -23,7 +24,13 @@ var ModuleBasics = append(
 	monitor.AppModuleBasic{},
 )
 
-// GetBabylonCdc returns Codec, i.e., struct for encoding/decoding messages, for Babylon
-func GetCodec() lensclient.Codec {
-	return lensclient.MakeCodec(ModuleBasics)
+// GetEncodingConfig returns EncodingConfig for Babylon
+func GetEncodingConfig() appparams.EncodingConfig {
+	lensCdc := lensclient.MakeCodec(ModuleBasics)
+	return appparams.EncodingConfig{
+		InterfaceRegistry: lensCdc.InterfaceRegistry,
+		Marshaler:         lensCdc.Marshaler,
+		TxConfig:          lensCdc.TxConfig,
+		Amino:             lensCdc.Amino,
+	}
 }


### PR DESCRIPTION
This PR adds `monitor.AppModuleBasic{}` to `config.ModuleBasics`, so that the rpc client knows how to serialise/deserialise messages in the monitor module.

In addition, it abstracts the code related to codec out to a new file, and creates a function that returns `EncodingConfig` for Babylon.