### PR TITLE
fix: Change tagIdx to uint8 from string to avoid bugs

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -3,9 +3,11 @@ package client
 import (
 	"fmt"
 
+	"cosmossdk.io/math"
+	lensclient "github.com/strangelove-ventures/lens/client"
+
 	"github.com/babylonchain/rpc-client/config"
 	"github.com/babylonchain/rpc-client/query"
-	lensclient "github.com/strangelove-ventures/lens/client"
 )
 
 var _ BabylonClient = &Client{}
@@ -46,12 +48,12 @@ func (c *Client) GetConfig() *config.BabylonConfig {
 }
 
 func (c *Client) GetTagIdx() uint8 {
-	tagIdxStr := c.cfg.TagIdx
-	if len(tagIdxStr) != 1 {
-		panic(fmt.Errorf("tag index should be one byte"))
+	tagIdx, err := math.ParseUint(c.cfg.TagIdx)
+	if err != nil {
+		panic(fmt.Errorf("invalid tag index"))
 	}
 	// convert tagIdx from string to its ascii value
-	return uint8(rune(tagIdxStr[0]))
+	return uint8(tagIdx.Uint64())
 }
 
 func (c *Client) Stop() {

--- a/client/client.go
+++ b/client/client.go
@@ -1,9 +1,6 @@
 package client
 
 import (
-	"fmt"
-
-	"cosmossdk.io/math"
 	lensclient "github.com/strangelove-ventures/lens/client"
 
 	"github.com/babylonchain/rpc-client/config"
@@ -48,12 +45,7 @@ func (c *Client) GetConfig() *config.BabylonConfig {
 }
 
 func (c *Client) GetTagIdx() uint8 {
-	tagIdx, err := math.ParseUint(c.cfg.TagIdx)
-	if err != nil {
-		panic(fmt.Errorf("invalid tag index"))
-	}
-	// convert tagIdx from string to its ascii value
-	return uint8(tagIdx.Uint64())
+	return c.cfg.TagIdx
 }
 
 func (c *Client) Stop() {

--- a/client/interface.go
+++ b/client/interface.go
@@ -3,9 +3,10 @@ package client
 import (
 	btcctypes "github.com/babylonchain/babylon/x/btccheckpoint/types"
 	btclctypes "github.com/babylonchain/babylon/x/btclightclient/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/babylonchain/rpc-client/config"
 	bbnquery "github.com/babylonchain/rpc-client/query"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 type BabylonClient interface {

--- a/config/babylon_config.go
+++ b/config/babylon_config.go
@@ -28,18 +28,18 @@ type BabylonConfig struct {
 	OutputFormat     string        `mapstructure:"output-format"`
 	SignModeStr      string        `mapstructure:"sign-mode"`
 	SubmitterAddress string        `mapstructure:"submitter-address"`
-	TagIdx           string        `mapstructure:"tag-idx"`
+	TagIdx           uint8         `mapstructure:"tag-idx"`
 }
 
 func (cfg *BabylonConfig) Validate() error {
 	if _, err := url.Parse(cfg.RPCAddr); err != nil {
-		return fmt.Errorf("cfg.RPCAddr is not correctly formatted: %w", err)
+		return fmt.Errorf("rpc-addr is not correctly formatted: %w", err)
 	}
 	if cfg.Timeout <= 0 {
-		return fmt.Errorf("cfg.Timeout must be positive")
+		return fmt.Errorf("timeout must be positive")
 	}
 	if cfg.BlockTimeout < 0 {
-		return fmt.Errorf("cfg.BlockTimeout can't be negative")
+		return fmt.Errorf("block-timeout can't be negative")
 	}
 	return nil
 }
@@ -83,7 +83,7 @@ func DefaultBabylonConfig() BabylonConfig {
 		OutputFormat:     "json",
 		SignModeStr:      "direct",
 		SubmitterAddress: "bbn1v6k7k9s8md3k29cu9runasstq5zaa0lpznk27w", // this is currently a placeholder, will not recognized by Babylon
-		TagIdx:           "0",
+		TagIdx:           0,
 	}
 }
 


### PR DESCRIPTION
`GetTagIdx` has a bug to parse a string to `uint8` as a `uint8` could take up to 3 characters, e.g., "255". So, this PR changed the type of `tagIdx` to `uint8` to avoid parsing errors.